### PR TITLE
Minor fix for problems experienced on Samsung Galaxy S3 mini

### DIFF
--- a/wheel/src/kankan/wheel/widget/WheelView.java
+++ b/wheel/src/kankan/wheel/widget/WheelView.java
@@ -662,7 +662,7 @@ public class WheelView extends View {
 		}
 
 		switch (event.getAction()) {
-			case MotionEvent.ACTION_MOVE:
+			case MotionEvent.ACTION_DOWN:
 				if (getParent() != null) {
 					getParent().requestDisallowInterceptTouchEvent(true);
 				}


### PR DESCRIPTION
On some devices WheelView has been unresponsive and very hard to use. The problem has been identified on Samsung S3 Mini - the wheel was unresponsive unless you have pressed wheel for a while and start scrolling after that.
The problem was also reproducable on Samsung S3 but only if user scrolled the wheel very very fast…

After connecting both phones to ADB and quick investigation of LogCat I have found out that MotionEvent.ACTION_MOVE has never been processed by WheelView. The reason was that MotionEvent.ACTION_CANCELED has been received immediately after MotionEvent.ACTION_DOWN. So I updated onTouchEvent method to call getParent().requestDisallowInterceptTouchEvent(true) immediately after ACTION_DOWN event has been detected.
