### PR TITLE
Fix width estimate in WheelView.java

### DIFF
--- a/wheel/src/kankan/wheel/widget/WheelView.java
+++ b/wheel/src/kankan/wheel/widget/WheelView.java
@@ -864,8 +864,8 @@ public class WheelView extends View {
 		}
 
 		// add views
-		int addItems = visibleItems / 2;
-		for (int i = currentItem + addItems; i >= currentItem - addItems; i--) {
+		// all items must be included to measure width correctly
+		for (int i = viewAdapter.getItemsCount()-1; i >= 0; i--){
 			if (addViewItem(i, true)) {
 				firstItem = i;
 			}


### PR DESCRIPTION
WheelView method buildViewForMeasuring() used only first three items to estimate
required width. This is often wrong, as can be seen in the second wheel on the
Time 2 Demo (the next ten entries after 9 are all 1, followed by four 2s).