### PR TITLE
Fix a bug about "java.lang.ArithmeticException: divide by zero"

### DIFF
--- a/wheel/src/kankan/wheel/widget/WheelView.java
+++ b/wheel/src/kankan/wheel/widget/WheelView.java
@@ -744,7 +744,11 @@ public class WheelView extends View {
 		// update offset
 		scrollingOffset = offset - count * itemHeight;
 		if (scrollingOffset > getHeight()) {
-			scrollingOffset = scrollingOffset % getHeight() + getHeight();
+			if(getHeight() <= 0){
+				scrollingOffset = 0;
+			}else {
+				scrollingOffset = scrollingOffset % getHeight() + getHeight();
+			}
 		}
 	}
 


### PR DESCRIPTION
When the wheelview is scrolling ,if the height of wheelview or it's parent view is set to 0, then the program will encounter a bug showing "java.lang.ArithmeticException: divide by zero".